### PR TITLE
better click handler

### DIFF
--- a/pdfannotate.js
+++ b/pdfannotate.js
@@ -97,10 +97,26 @@ var PDFAnnotate = function (container_id, url, options = {}) {
         background,
         fabricObj.renderAll.bind(fabricObj)
       );
-      $(fabricObj.upperCanvasEl).click(function (event) {
-        inst.active_canvas = index;
-        inst.fabricClickHandler(event, fabricObj);
-      });
+
+      $(fabricObj.upperCanvasEl).on('mousedown', function(e) {
+        $(this).data('p0', {
+          x: e.pageX,
+          y: e.pageY
+        });
+      }).on('mouseup', function(e) {
+        var p0 = $(this).data('p0'),
+          p1 = {
+            x: e.pageX,
+            y: e.pageY
+          },
+          d = Math.sqrt(Math.pow(p1.x - p0.x, 2) + Math.pow(p1.y - p0.y, 2));
+
+        if (d < 4) {
+          inst.active_canvas = index;
+          inst.fabricClickHandler(e, fabricObj);
+        }
+      })
+
       fabricObj.on('after:render', function () {
         inst.fabricObjectsData[index] = fabricObj.toJSON();
         fabricObj.off('after:render');


### PR DESCRIPTION
When creating rectangles, it is counterintuitive that if the rectangle tool is selected and I try to resize or move another object, it will draw another rectangle. This only triggers the handler if it is a plain click.